### PR TITLE
Flexibility fixes

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -5,8 +5,11 @@
 class supervisord(
   $package_ensure       = $supervisord::params::package_ensure,
   $package_name         = $supervisord::params::package_name,
+  $package_enable       = $supervisord::params::package_enable,
+  $package_manage       = $supervisord::params::package_manage,
   $package_provider     = $supervisord::params::package_provider,
   $service_ensure       = $supervisord::params::service_ensure,
+  $service_manage       = $supervisord::params::service_manage,
   $service_name         = $supervisord::params::service_name,
   $install_init         = $supervisord::params::install_init,
   $install_pip          = false,
@@ -123,7 +126,13 @@ class supervisord(
     Class['supervisord::pip'] -> Class['supervisord::install']
   }
 
-  include supervisord::install, supervisord::config, supervisord::service, supervisord::reload
+  include supervisord::config, supervisord::reload
+  if $package_manage == true {
+    include supervisord::install
+  }
+  if $service_manage == true {
+    include supervisord::service
+  }
 
   Class['supervisord::install'] -> Class['supervisord::config'] ~> Class['supervisord::service']
   Class['supervisord::reload'] -> Supervisord::Supervisorctl <| |>

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -126,13 +126,7 @@ class supervisord(
     Class['supervisord::pip'] -> Class['supervisord::install']
   }
 
-  include supervisord::config, supervisord::reload
-  if $package_manage == true {
-    include supervisord::install
-  }
-  if $service_manage == true {
-    include supervisord::service
-  }
+  include supervisord::config, supervisord::reload, supervisord::install, supervisord::service
 
   Class['supervisord::install'] -> Class['supervisord::config'] ~> Class['supervisord::service']
   Class['supervisord::reload'] -> Supervisord::Supervisorctl <| |>

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -3,8 +3,10 @@
 # Installs supervisor package (defaults to using pip)
 #
 class supervisord::install inherits supervisord {
-  package { $supervisord::package_name:
-    ensure   => $supervisord::package_ensure,
-    provider => $supervisord::package_provider
+  if $supervisord::package_manage == true {
+      package { $supervisord::package_name:
+        ensure   => $supervisord::package_ensure,
+        provider => $supervisord::package_provider
+      }
   }
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -26,8 +26,11 @@ class supervisord::params {
 
   # default supervisord params
   $package_ensure       = 'installed'
+  $package_enable       = true
+  $package_manage       = true
   $package_provider     = 'pip'
   $service_ensure       = 'running'
+  $service_manage       = true
   $service_name         = 'supervisord'
   $package_name         = 'supervisor'
   $executable           = "${executable_path}/supervisord"

--- a/manifests/reload.pp
+++ b/manifests/reload.pp
@@ -6,14 +6,16 @@ class supervisord::reload inherits supervisord {
 
   $supervisorctl = $::supervisord::executable_ctl
 
-  exec { 'supervisorctl_reread':
-    command     => "${supervisorctl} reread",
-    refreshonly => true,
-    require     => Service[$supervisord::service_name],
-  }
-  exec { 'supervisorctl_update':
-    command     => "${supervisorctl} update",
-    refreshonly => true,
-    require     => Service[$supervisord::service_name],
+  if $supervisord::service_manage == true {
+    exec { 'supervisorctl_reread':
+      command     => "${supervisorctl} reread",
+      refreshonly => true,
+      require     => Service[$supervisord::service_name],
+    }
+    exec { 'supervisorctl_update':
+      command     => "${supervisorctl} update",
+      refreshonly => true,
+      require     => Service[$supervisord::service_name],
+    }
   }
 }

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -3,10 +3,12 @@
 # Class for the supervisord service
 #
 class supervisord::service inherits supervisord  {
-  service { $supervisord::service_name:
-    ensure     => $supervisord::service_ensure,
-    enable     => $supervisord::package_enable,
-    hasrestart => true,
-    hasstatus  => true
+  if $supervisord::service_manage == true {
+    service { $supervisord::service_name:
+      ensure     => $supervisord::service_ensure,
+      enable     => $supervisord::package_enable,
+      hasrestart => true,
+      hasstatus  => true
+    }
   }
 }

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -11,4 +11,12 @@ class supervisord::service inherits supervisord  {
       hasstatus  => true
     }
   }
+  else {
+    service { $supervisord::service_name:
+      ensure     => stopped,
+      enable     => false,
+      hasrestart => false,
+      hasstatus  => false, 
+    }
+  }
 }

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -3,10 +3,12 @@
 # Class for the supervisord service
 #
 class supervisord::service inherits supervisord  {
-  service { $supervisord::service_name:
-    ensure     => $supervisord::service_ensure,
-    enable     => true,
-    hasrestart => true,
-    hasstatus  => true
+  if $supervisord::service_manage == true {
+    service { $supervisord::service_name:
+      ensure     => $supervisord::service_ensure,
+      enable     => $supervisord::service_enable,
+      hasrestart => true,
+      hasstatus  => true
+    }
   }
 }

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -3,20 +3,10 @@
 # Class for the supervisord service
 #
 class supervisord::service inherits supervisord  {
-  if $supervisord::service_manage == true {
-    service { $supervisord::service_name:
-      ensure     => $supervisord::service_ensure,
-      enable     => $supervisord::package_enable,
-      hasrestart => true,
-      hasstatus  => true
-    }
-  }
-  else {
-    service { $supervisord::service_name:
-      ensure     => stopped,
-      enable     => false,
-      hasrestart => false,
-      hasstatus  => false, 
-    }
+  service { $supervisord::service_name:
+    ensure     => $supervisord::service_ensure,
+    enable     => $supervisord::package_enable,
+    hasrestart => true,
+    hasstatus  => true
   }
 }

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -6,7 +6,7 @@ class supervisord::service inherits supervisord  {
   if $supervisord::service_manage == true {
     service { $supervisord::service_name:
       ensure     => $supervisord::service_ensure,
-      enable     => $supervisord::service_enable,
+      enable     => $supervisord::package_enable,
       hasrestart => true,
       hasstatus  => true
     }


### PR DESCRIPTION
Added a few options so I could use this in a docker container which doesn't have a normal init system.  The options are service_manage and package_manage so that I can manage them outside of this module without puppet duplicate Service['supervisord'] and Package['supervisord'] errors.