### PR TITLE
Setuptools new url

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -46,7 +46,7 @@ class supervisord::params {
   $umask                = '022'
   $config_include       = '/etc/supervisor.d'
   $config_file          = '/etc/supervisord.conf'
-  $setuptools_url       = 'https://bitbucket.org/pypa/setuptools/raw/bootstrap/ez_setup.py'
+  $setuptools_url       = 'https://github.org/pypa/setuptools/raw/bootstrap/ez_setup.py'
 
   $unix_socket          = true
   $unix_socket_file     = 'supervisor.sock'

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -46,7 +46,7 @@ class supervisord::params {
   $umask                = '022'
   $config_include       = '/etc/supervisor.d'
   $config_file          = '/etc/supervisord.conf'
-  $setuptools_url       = 'https://github.org/pypa/setuptools/raw/bootstrap/ez_setup.py'
+  $setuptools_url       = 'https://github.com/pypa/setuptools/raw/bootstrap/ez_setup.py'
 
   $unix_socket          = true
   $unix_socket_file     = 'supervisor.sock'


### PR DESCRIPTION
Pypa have moved their setuptools repo to Github, causing a 404 when provisioning. This points to the correct url for the bootstrapper.